### PR TITLE
Local echo server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # http-requestor-proxy
+
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r requirements.txt
+    docker build . -f echo_server.Dockerfile -t echo_server
+    docker run -d -p "8001:8001" --name echo_server echo_server
+    ECHO_SERVER_URL="http://localhost:8001/" pytest
+    docker stop echo_server

--- a/echo_server.Dockerfile
+++ b/echo_server.Dockerfile
@@ -1,11 +1,17 @@
-FROM python:3.8-slim
+#   TODO: change to -slim when development is finished
+FROM python:3.8
 
 WORKDIR /echo_server
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-COPY echo_server.py          echo_server.py
+COPY golem_provider_mock.py  golem_provider_mock.py
 COPY serializable_request.py serializable_request.py
 
-CMD gunicorn -b 0.0.0.0:8001 "echo_server:app"
+COPY echo_server.py          echo_server.py
+
+#   NOTE: second gunicorn is a mock of the final interface
+CMD ["sh", "-c", "\
+        gunicorn -b unix:///tmp/golem.sock echo_server:app --daemon; \
+        gunicorn -b 0.0.0.0:8001 golem_provider_mock:app"]

--- a/echo_server.Dockerfile
+++ b/echo_server.Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8-slim
+
+WORKDIR /echo_server
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY echo_server.py          echo_server.py
+COPY serializable_request.py serializable_request.py
+
+CMD gunicorn -b 0.0.0.0:8001 "echo_server:app"

--- a/echo_server.py
+++ b/echo_server.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from serializable_request import Request
+
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+app = Flask(__name__)
+
+
+@app.route('/', defaults={'path': ''}, methods=HTTP_METHODS)
+@app.route('/<path:path>', methods=HTTP_METHODS)
+def echo(path):
+    '''
+    Whole request is returned (including headers etc) to simplify testing.
+    Echo server has no non-testing purpose.
+    '''
+    req = Request.from_flask_request()
+    out_data = {
+        'echo': 'echo',
+        'req': req.as_dict(),
+    }
+    return out_data, 200

--- a/golem_provider_mock.py
+++ b/golem_provider_mock.py
@@ -1,0 +1,32 @@
+'''
+Provider-side code goes here.
+Everything Flask-related will be removed, but something similar to send_request_from_file will remain.
+
+Some things here are ugly, but they will be replaced.
+'''
+
+
+from flask import Flask
+from serializable_request import Request
+from tempfile import NamedTemporaryFile
+import requests_unixsocket
+
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+app = Flask(__name__)
+
+
+def send_request_from_file(fname):
+    req = Request.from_file(fname)
+    req.replace_mount_url('http://localhost/', 'http+unix://%2Ftmp%2Fgolem.sock/')
+    session = requests_unixsocket.Session()
+    return session.send(req.as_requests_request().prepare())
+
+
+@app.route('/', defaults={'path': ''}, methods=HTTP_METHODS)
+@app.route('/<path:path>', methods=HTTP_METHODS)
+def catch_all(path):
+    req = Request.from_flask_request()
+    with NamedTemporaryFile() as f:
+        req.to_file(f.name)
+        res = send_request_from_file(f.name)
+    return res.content, res.status_code, res.headers.items()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==1.1.2
 requests==2.25.1
 pytest==6.2.3
 requests_flask_adapter==0.1.0
+gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.25.1
 pytest==6.2.3
 requests_flask_adapter==0.1.0
 gunicorn==20.1.0
+requests-unixsocket==0.2.0

--- a/serializable_request.py
+++ b/serializable_request.py
@@ -9,6 +9,11 @@ class Request():
         self.data = data
         self.headers = headers
 
+    def replace_mount_url(self, old, new):
+        if not self.url.startswith(old):
+            raise ValueError(f"current url doesn't start with {old}")
+        self.url = self.url.replace(old, new, 1)
+
     @classmethod
     def from_flask_request(cls):
         from flask import request

--- a/serializable_request.py
+++ b/serializable_request.py
@@ -34,13 +34,15 @@ class Request():
             f.write(self.as_json())
 
     def as_json(self):
-        data = {
+        return json.dumps(self.as_dict())
+
+    def as_dict(self):
+        return {
             'method': self.method,
             'url': self.url,
             'data': self.data.decode('utf-8'),
             'headers': self.headers,
         }
-        return json.dumps(data)
 
     def as_requests_request(self):
         req = requests.Request(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,8 @@ def clean_headers(headers):
     '''
     1. Remove headers added by request_flask_adapter (used only for testing)
     2. Lowercase http header names, we are case insensitive
+    3. Remove 'accept-encoding': 'identity' header, added by http.client (deep inside requests)
+       https://stackoverflow.com/a/18706328
     '''
     out = dict(headers)
     if out.get('User-Agent', '') == 'RequestsFlask/0.0.1':
@@ -10,6 +12,10 @@ def clean_headers(headers):
         del out['Host']
 
     out = {key.lower(): val for key, val in out.items()}
+
+    if out.get('accept-encoding', '') == 'identity':
+        del out['accept-encoding']
+
     return out
 
 

--- a/tests/sample_requests.py
+++ b/tests/sample_requests.py
@@ -33,4 +33,8 @@ sample_requests = [
     Request('post', BASE_URL, cookies={'aa': 'bb'}),
 
     Request('post', BASE_URL, auth=('aa', 'zz')),
+
+    #   requests do something with accept-encoding (--> compare tests.helpers.clean_headers)
+    Request('get', BASE_URL, headers={'accept-encoding': 'gzip'}),
+    Request('get', BASE_URL, headers={'Accept-Encoding': 'gzip', 'Something-Else': 'nope'}),
 ]

--- a/tests/test_echo_server.py
+++ b/tests/test_echo_server.py
@@ -1,0 +1,38 @@
+from .sample_requests import sample_requests, BASE_URL
+from .helpers import clean_headers, clean_body
+
+import pytest
+
+from serializable_request import Request
+from requests_flask_adapter import Session
+import catchall_server
+import echo_server
+
+ECHO_URL = 'http://echo/'
+Session.register(BASE_URL, catchall_server.app)
+Session.register(ECHO_URL, echo_server.app)
+
+
+def request_flask_adapter_forward():
+    req = Request.from_flask_request()
+    req.url = req.url.replace(BASE_URL, ECHO_URL)
+    echo_res = Session().send(req.as_requests_request().prepare())
+    return echo_res.content, echo_res.status_code, echo_res.headers.items()
+
+
+@pytest.mark.parametrize('forward_func', [request_flask_adapter_forward])
+@pytest.mark.parametrize('src_req', sample_requests)
+def test_echo_server(forward_func, src_req):
+    catchall_server.forward_request = forward_func
+    prepped = src_req.prepare()
+
+    res = Session().send(prepped)
+    assert res.status_code == 200
+
+    echo_req_data = res.json()['req']
+    echo_prepped = Request(**echo_req_data).as_requests_request().prepare()
+
+    assert prepped.method == echo_prepped.method
+    assert prepped.url == echo_prepped.url
+    assert clean_headers(prepped.headers) == clean_headers(echo_prepped.headers)
+    assert clean_body(prepped.body) == clean_body(echo_prepped.body)


### PR DESCRIPTION
This is a follow-up to the first PR (https://github.com/golemfactory/http-requestor-proxy/pull/1) - not merged yet, so PR is to the other branch, not `main`.

https://golemproject.atlassian.net/browse/APPS-90
https://golemproject.atlassian.net/browse/APPS-91

Things done:
* echo server
* running in docker container
* running on a unix socket ( --> should work with current yagna)

There is no more "general" (not touching Golem directly) work to be done in https://golemproject.atlassian.net/browse/APPS-86.

NOTE: everything related to `golem_provider_mock.py` could be ugly because it will be replaced.

```
$ python3 -m venv .venv
$ . .venv/bin/activate
$ pip install -r requirements.txt
$ docker build . -f echo_server.Dockerfile -t echo_server
$ docker run -d -p "8001:8001" --name echo_server echo_server
$ ECHO_SERVER_URL="http://localhost:8001/" pytest
$ docker stop echo_server
```

